### PR TITLE
Investigate and fix itinerary save error

### DIFF
--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -305,11 +305,23 @@ export function mergeItineraryData(
     });
   }
 
+  // 日付フィールドを常にDateオブジェクトに変換
+  // APIレスポンスでは文字列になっている可能性があるため
+  const createdAt = updates.createdAt 
+    ? (updates.createdAt instanceof Date ? updates.createdAt : new Date(updates.createdAt))
+    : baseData.createdAt;
+  
+  const publishedAt = updates.publishedAt
+    ? (updates.publishedAt instanceof Date ? updates.publishedAt : new Date(updates.publishedAt))
+    : baseData.publishedAt;
+
   return {
     ...baseData,
     ...updates,
     schedule: mergedSchedule,
+    createdAt,
     updatedAt: now,
+    publishedAt,
   };
 }
 

--- a/lib/mock-data/itineraries.ts
+++ b/lib/mock-data/itineraries.ts
@@ -417,8 +417,9 @@ export const loadItinerariesFromStorage = (): ItineraryData[] => {
     // Date型に変換
     return parsed.map((item: any) => ({
       ...item,
-      createdAt: new Date(item.createdAt),
-      updatedAt: new Date(item.updatedAt),
+      createdAt: item.createdAt ? new Date(item.createdAt) : new Date(),
+      updatedAt: item.updatedAt ? new Date(item.updatedAt) : new Date(),
+      publishedAt: item.publishedAt ? new Date(item.publishedAt) : undefined,
     }));
   } catch (error) {
     console.error('Failed to load itineraries from storage:', error);

--- a/lib/utils/storage.ts
+++ b/lib/utils/storage.ts
@@ -318,11 +318,23 @@ export function saveCurrentItinerary(itinerary: ItineraryData | null): boolean {
       return true;
     }
     
+    // 日付フィールドを文字列に変換（既に文字列の場合はそのまま使用）
+    const createdAtStr = itinerary.createdAt instanceof Date 
+      ? itinerary.createdAt.toISOString()
+      : itinerary.createdAt;
+    const updatedAtStr = itinerary.updatedAt instanceof Date
+      ? itinerary.updatedAt.toISOString()
+      : itinerary.updatedAt;
+    const publishedAtStr = itinerary.publishedAt 
+      ? (itinerary.publishedAt instanceof Date ? itinerary.publishedAt.toISOString() : itinerary.publishedAt)
+      : undefined;
+    
     // しおりデータをJSON化して保存
     const serialized = JSON.stringify({
       ...itinerary,
-      createdAt: itinerary.createdAt.toISOString(),
-      updatedAt: itinerary.updatedAt.toISOString(),
+      createdAt: createdAtStr,
+      updatedAt: updatedAtStr,
+      publishedAt: publishedAtStr,
     });
     
     window.localStorage.setItem(STORAGE_KEYS.CURRENT_ITINERARY, serialized);
@@ -354,8 +366,9 @@ export function loadCurrentItinerary(): ItineraryData | null {
     // Date型に変換
     return {
       ...data,
-      createdAt: new Date(data.createdAt),
-      updatedAt: new Date(data.updatedAt),
+      createdAt: data.createdAt ? new Date(data.createdAt) : new Date(),
+      updatedAt: data.updatedAt ? new Date(data.updatedAt) : new Date(),
+      publishedAt: data.publishedAt ? new Date(data.publishedAt) : undefined,
     } as ItineraryData;
   } catch (error) {
     console.error('Failed to load current itinerary:', error);
@@ -447,7 +460,20 @@ export function loadPublicItineraries(): Record<string, any> {
     if (!data) {
       return {};
     }
-    return JSON.parse(data);
+    const parsed = JSON.parse(data);
+    
+    // 各しおりの日付フィールドをDateオブジェクトに変換
+    const result: Record<string, any> = {};
+    for (const [slug, itinerary] of Object.entries(parsed)) {
+      result[slug] = {
+        ...itinerary,
+        createdAt: (itinerary as any).createdAt ? new Date((itinerary as any).createdAt) : new Date(),
+        updatedAt: (itinerary as any).updatedAt ? new Date((itinerary as any).updatedAt) : new Date(),
+        publishedAt: (itinerary as any).publishedAt ? new Date((itinerary as any).publishedAt) : undefined,
+      };
+    }
+    
+    return result;
   } catch (error) {
     console.error('Failed to load public itineraries:', error);
     return {};


### PR DESCRIPTION
Fix `TypeError: itinerary.createdAt.toISOString is not a function` by ensuring itinerary date fields are consistently handled as Date objects.

`createdAt` and `updatedAt` were sometimes stored as strings from API responses, leading to `TypeError` when `toISOString()` was called. This PR ensures these fields are always converted to Date objects upon loading/merging and correctly serialized to strings upon saving.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b6c6a57-9a3a-4b0c-9adc-cfcedd6c6719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4b6c6a57-9a3a-4b0c-9adc-cfcedd6c6719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

