### PR TITLE
Fix infinite scroll on pc

### DIFF
--- a/components/layout/ResizableLayout.tsx
+++ b/components/layout/ResizableLayout.tsx
@@ -24,7 +24,7 @@ export const ResizableLayout: React.FC = () => {
   const itineraryPanelWidth = 100 - chatPanelWidth;
 
   return (
-    <div className="flex-1 flex overflow-hidden">
+    <div className="h-full flex overflow-hidden">
       {/* Chat Box - Left Side (動的幅) */}
       <div
         style={{ width: `${chatPanelWidth}%` }}


### PR DESCRIPTION
Fix infinite vertical scroll on PC by changing `flex-1` to `h-full` in `ResizableLayout.tsx`.

The `flex-1` utility was applied in both the parent (`app/page.tsx`) and child (`ResizableLayout.tsx`) elements, leading to an infinite height calculation on desktop views.

---
<a href="https://cursor.com/background-agent?bcId=bc-f402ab28-623c-4df7-8ec0-0396710998cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f402ab28-623c-4df7-8ec0-0396710998cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

